### PR TITLE
Fixed a bug which removes the xmlns attributes in metadata element

### DIFF
--- a/src/main/java/com/lyncode/xoai/dataprovider/xml/EchoElement.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/xml/EchoElement.java
@@ -9,6 +9,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.XMLEvent;
 import java.io.ByteArrayInputStream;
 import java.util.Iterator;
@@ -32,6 +33,12 @@ public class EchoElement implements XMLWritable {
                 if (event.isStartElement()) {
                     QName name = event.asStartElement().getName();
                     context.getWriter().writeStartElement(name.getPrefix(), name.getLocalPart(), name.getNamespaceURI());
+
+                    Iterator<Namespace> it_ns = event.asStartElement().getNamespaces();
+                    while (it_ns.hasNext()) {
+                        Namespace ns = it_ns.next();
+                        context.getWriter().writeNamespace(ns.getPrefix(), ns.getNamespaceURI());
+                    }
 
                     @SuppressWarnings("unchecked")
                     Iterator<Attribute> it = event.asStartElement().getAttributes();


### PR DESCRIPTION
The current xoai removes the `xmlns` attributes specified at metadata root element in its xslt. This patch fixes this problem.

For example with oai_dc,

Current xaoi-3.2.7 writes as follows:

```
<oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
               http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
```

xaoi-3.2.7 with this patch writes:

```
<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
           xmlns:doc="http://www.lyncode.com/xoai"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:dc="http://purl.org/dc/elements/1.1/"
           xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
               http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
```
