### PR TITLE
[Fix] Handlers using the HTTPOAIClient now close the previous connection

### DIFF
--- a/xoai-service-provider/src/main/java/com/lyncode/xoai/serviceprovider/client/HttpOAIClient.java
+++ b/xoai-service-provider/src/main/java/com/lyncode/xoai/serviceprovider/client/HttpOAIClient.java
@@ -16,8 +16,9 @@
 
 package com.lyncode.xoai.serviceprovider.client;
 
-import com.lyncode.xoai.serviceprovider.exceptions.HttpException;
-import com.lyncode.xoai.serviceprovider.parameters.Parameters;
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
@@ -25,8 +26,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.DefaultHttpClient;
 
-import java.io.IOException;
-import java.io.InputStream;
+import com.lyncode.xoai.serviceprovider.exceptions.HttpException;
+import com.lyncode.xoai.serviceprovider.parameters.Parameters;
 
 public class HttpOAIClient implements OAIClient {
     private String baseUrl;

--- a/xoai-service-provider/src/main/java/com/lyncode/xoai/serviceprovider/handler/ListIdentifierHandler.java
+++ b/xoai-service-provider/src/main/java/com/lyncode/xoai/serviceprovider/handler/ListIdentifierHandler.java
@@ -16,6 +16,25 @@
 
 package com.lyncode.xoai.serviceprovider.handler;
 
+import static com.lyncode.xml.matchers.QNameMatchers.localPart;
+import static com.lyncode.xml.matchers.XmlEventMatchers.aStartElement;
+import static com.lyncode.xml.matchers.XmlEventMatchers.anEndElement;
+import static com.lyncode.xml.matchers.XmlEventMatchers.elementName;
+import static com.lyncode.xml.matchers.XmlEventMatchers.text;
+import static com.lyncode.xoai.model.oaipmh.Verb.Type.ListIdentifiers;
+import static com.lyncode.xoai.serviceprovider.parameters.Parameters.parameters;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.AllOf.allOf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.stream.events.XMLEvent;
+
+import org.hamcrest.Matcher;
+
 import com.lyncode.xml.XmlReader;
 import com.lyncode.xml.exceptions.XmlReaderException;
 import com.lyncode.xoai.model.oaipmh.Header;
@@ -26,19 +45,6 @@ import com.lyncode.xoai.serviceprovider.lazy.Source;
 import com.lyncode.xoai.serviceprovider.model.Context;
 import com.lyncode.xoai.serviceprovider.parameters.ListIdentifiersParameters;
 import com.lyncode.xoai.serviceprovider.parsers.ListIdentifiersParser;
-import org.hamcrest.Matcher;
-
-import javax.xml.stream.events.XMLEvent;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.lyncode.xml.matchers.QNameMatchers.localPart;
-import static com.lyncode.xml.matchers.XmlEventMatchers.*;
-import static com.lyncode.xoai.model.oaipmh.Verb.Type.ListIdentifiers;
-import static com.lyncode.xoai.serviceprovider.parameters.Parameters.parameters;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.core.AllOf.allOf;
 
 public class ListIdentifierHandler implements Source<Header> {
     private Context context;
@@ -83,12 +89,16 @@ public class ListIdentifierHandler implements Source<Header> {
                         resumptionToken = text;
                 } else ended = true;
             } else ended = true;
+            stream.close();
             return headers;
         } catch (XmlReaderException e) {
             throw new InvalidOAIResponse(e);
         } catch (OAIRequestException e) {
             throw new InvalidOAIResponse(e);
         }
+        catch (IOException e) {
+        	throw new InvalidOAIResponse(e);
+		}
     }
 
     private Matcher<XMLEvent> resumptionToken() {

--- a/xoai-service-provider/src/main/java/com/lyncode/xoai/serviceprovider/handler/ListRecordHandler.java
+++ b/xoai-service-provider/src/main/java/com/lyncode/xoai/serviceprovider/handler/ListRecordHandler.java
@@ -16,6 +16,25 @@
 
 package com.lyncode.xoai.serviceprovider.handler;
 
+import static com.lyncode.xml.matchers.QNameMatchers.localPart;
+import static com.lyncode.xml.matchers.XmlEventMatchers.aStartElement;
+import static com.lyncode.xml.matchers.XmlEventMatchers.anEndElement;
+import static com.lyncode.xml.matchers.XmlEventMatchers.elementName;
+import static com.lyncode.xml.matchers.XmlEventMatchers.text;
+import static com.lyncode.xoai.model.oaipmh.Verb.Type.ListRecords;
+import static com.lyncode.xoai.serviceprovider.parameters.Parameters.parameters;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.AllOf.allOf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.stream.events.XMLEvent;
+
+import org.hamcrest.Matcher;
+
 import com.lyncode.xml.XmlReader;
 import com.lyncode.xml.exceptions.XmlReaderException;
 import com.lyncode.xoai.model.oaipmh.Record;
@@ -26,19 +45,6 @@ import com.lyncode.xoai.serviceprovider.lazy.Source;
 import com.lyncode.xoai.serviceprovider.model.Context;
 import com.lyncode.xoai.serviceprovider.parameters.ListRecordsParameters;
 import com.lyncode.xoai.serviceprovider.parsers.ListRecordsParser;
-import org.hamcrest.Matcher;
-
-import javax.xml.stream.events.XMLEvent;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.lyncode.xml.matchers.QNameMatchers.localPart;
-import static com.lyncode.xml.matchers.XmlEventMatchers.*;
-import static com.lyncode.xoai.model.oaipmh.Verb.Type.ListRecords;
-import static com.lyncode.xoai.serviceprovider.parameters.Parameters.parameters;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.core.AllOf.allOf;
 
 public class ListRecordHandler implements Source<Record> {
     private Context context;
@@ -55,6 +61,7 @@ public class ListRecordHandler implements Source<Record> {
 
     @Override
     public List<Record> nextIteration() {
+    	//TODO - refactor - this and ListIdentifierHandler are pretty similar.
         List<Record> records = new ArrayList<Record>();
         try {
             InputStream stream = null;
@@ -84,12 +91,17 @@ public class ListRecordHandler implements Source<Record> {
                         resumptionToken = text;
                 } else ended = true;
             } else ended = true;
+			
+            stream.close();
             return records;
         } catch (XmlReaderException e) {
             throw new InvalidOAIResponse(e);
         } catch (OAIRequestException e) {
             throw new InvalidOAIResponse(e);
         }
+        catch (IOException e) {
+        	throw new InvalidOAIResponse(e);
+		}
     }
 
     private Matcher<XMLEvent> resumptionToken() {


### PR DESCRIPTION
Before retrieving the next iteration of results from a new request the httpClient needs to close the previous stream.
