### PR TITLE
Improve handling of XML namespaces

### DIFF
--- a/xoai-common/src/main/java/org/dspace/xoai/xml/EchoElement.java
+++ b/xoai-common/src/main/java/org/dspace/xoai/xml/EchoElement.java
@@ -16,17 +16,18 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.XMLEvent;
 import java.io.ByteArrayInputStream;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
-
+import java.util.Set;
+import java.util.Stack;
 
 public class EchoElement implements XmlWritable {
     private static XMLInputFactory factory = XMLInputFactory2.newFactory();
     private String xmlString = null;
-    private List<String> declaredPrefixes = new ArrayList<String>();
+    private Stack<Set<String>> declaredPrefixes = new Stack<Set<String>>();
 
     public EchoElement(String xmlString) {
         this.xmlString = xmlString;
@@ -40,10 +41,20 @@ public class EchoElement implements XmlWritable {
                 XMLEvent event = reader.nextEvent();
 
                 if (event.isStartElement()) {
+                    declaredPrefixes.push(new HashSet<String>());
+
                     QName name = event.asStartElement().getName();
                     writer.writeStartElement(name.getPrefix(), name.getLocalPart(), name.getNamespaceURI());
                     addNamespaceIfRequired(writer, name);
 
+                    // Copy any other namespace declarations
+                    Iterator<Namespace> itNamespaces = event.asStartElement().getNamespaces();
+                    while (itNamespaces.hasNext()) {
+                        Namespace namespace = itNamespaces.next();
+                        addNamespaceIfRequired(writer, new QName(namespace.getNamespaceURI(), "", namespace.getPrefix()));
+                    }
+
+                    // Copy attributes
                     @SuppressWarnings("unchecked")
                     Iterator<Attribute> it = event.asStartElement().getAttributes();
 
@@ -54,6 +65,7 @@ public class EchoElement implements XmlWritable {
                         writer.writeAttribute(attrName.getPrefix(), attrName.getNamespaceURI(), attrName.getLocalPart(), attr.getValue());
                     }
                 } else if (event.isEndElement()) {
+                    declaredPrefixes.pop();
                     writer.writeEndElement();
                 } else if (event.isCharacters()) {
                     writer.writeCharacters(event.asCharacters().getData());
@@ -65,9 +77,14 @@ public class EchoElement implements XmlWritable {
     }
 
     private void addNamespaceIfRequired(XmlWriter writer, QName name) throws XMLStreamException {
-        if (!declaredPrefixes.contains(name.getPrefix())) {
-            writer.writeNamespace(name.getPrefix(), name.getNamespaceURI());
-            declaredPrefixes.add(name.getPrefix());
+        // Search for namespace in scope, starting from the root.
+        for (Set<String> ancestorNamespaces : declaredPrefixes) {
+            if (ancestorNamespaces.contains(name.getPrefix() + name.getNamespaceURI())) { // Prefixes might be reused.
+                return;
+            }
         }
+
+        writer.writeNamespace(name.getPrefix(), name.getNamespaceURI());
+        declaredPrefixes.peek().add(name.getPrefix() + name.getNamespaceURI());
     }
 }

--- a/xoai-common/src/main/java/org/dspace/xoai/xml/EchoElement.java
+++ b/xoai-common/src/main/java/org/dspace/xoai/xml/EchoElement.java
@@ -8,8 +8,6 @@
 
 package org.dspace.xoai.xml;
 
-import com.lyncode.xml.XmlWritable;
-import com.lyncode.xml.XmlWriter;
 import com.lyncode.xml.exceptions.XmlWriteException;
 import org.codehaus.stax2.XMLInputFactory2;
 

--- a/xoai-common/src/test/java/org/dspace/xoai/tests/util/EchoElementTest.java
+++ b/xoai-common/src/test/java/org/dspace/xoai/tests/util/EchoElementTest.java
@@ -1,0 +1,62 @@
+package org.dspace.xoai.tests.util;
+
+import com.lyncode.xml.exceptions.XmlWriteException;
+import org.dspace.xoai.xml.EchoElement;
+import org.dspace.xoai.xml.XmlWriter;
+import org.junit.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EchoElementTest {
+
+    /*
+     * Namespace declarations (such as 'dc' on the root element <oai_dc:dc> below) should be kept when provided, as they
+     * are likely to be used later.
+     */
+    @Test
+    public void handleEarlyNamespaceDeclarations() throws XMLStreamException, XmlWriteException, IOException {
+        String xml = "<?xml version='1.0' encoding='UTF-8'?>"
+                + "<oai_dc:dc xmlns:oai_dc=\"http://www.openarchives.org/OAI/2.0/oai_dc/\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd\">\n"
+                + "\t<dc:title>Invasive Lithobates catesbeianus - American bullfrog occurrences in Flanders</dc:title>\n"
+                + "\t<dc:subject>Occurrence</dc:subject>\n"
+                + "\t<dc:subject>Observation</dc:subject>\n"
+                + "</oai_dc:dc>";
+
+        String result = echoXml(xml);
+
+        assertEquals("EchoElement handles nested namespaces", xml, result);
+    }
+
+    /*
+     * Namespace declarations must be tracked according to the current context.  The sibling dc: elements below all need
+     * a namespace declaration.
+     */
+    @Test
+    public void repeatingNamespaceDeclarations() throws XMLStreamException, XmlWriteException, IOException {
+        String xml = "<?xml version='1.0' encoding='UTF-8'?>"
+                + "<oai_dc:dc xmlns:oai_dc=\"http://www.openarchives.org/OAI/2.0/oai_dc/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd\">\n"
+                + "\t<dc:title xmlns:dc=\"http://purl.org/dc/elements/1.1/\">Invasive Lithobates catesbeianus - American bullfrog occurrences in Flanders</dc:title>\n"
+                + "\t<dc:subject xmlns:dc=\"http://purl.org/dc/elements/1.1/\">Occurrence</dc:subject>\n"
+                + "\t<dc:subject xmlns:dc=\"http://purl.org/dc/elements/1.1/\">Observation</dc:subject>\n"
+                + "</oai_dc:dc>";
+
+        String result = echoXml(xml);
+
+        assertEquals("EchoElement handles nested namespaces", xml, result);
+    }
+
+    private String echoXml(String xml) throws XmlWriteException, XMLStreamException {
+        ByteArrayOutputStream resultStream = new ByteArrayOutputStream();
+
+        XmlWriter writer = new XmlWriter(resultStream);
+        writer.writeStartDocument();
+        writer.write(new EchoElement(xml));
+        writer.writeEndDocument();
+
+        return resultStream.toString();
+    }
+}


### PR DESCRIPTION
This fixes an issue I had serving metadata documents like this:

``` xml
<?xml version='1.0' encoding='UTF-8'?>
<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
    <dc:title>Invasive Lithobates catesbeianus - American bullfrog occurrences in Flanders</dc:title>
    <dc:subject>Occurrence</dc:subject>
    <dc:subject>Observation</dc:subject>
</oai_dc:dc>
```

which would become this:

``` xml
<?xml version='1.0' encoding='UTF-8'?>
<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Invasive Lithobates catesbeianus - American bullfrog occurrences in Flanders</dc:title>
    <dc:subject>Occurrence</dc:subject>
    <dc:subject>Observation</dc:subject>
</oai_dc:dc>
```

That's invalid — the `dc` namespace declaration has been lost from the root element, added to the `<dc:title>`, but not added to the `<dc:subject>`.

After the patch, the result is the same as the input.
