### PR TITLE
Service provider to support ListMetadataFormats returning the error 'idDoesNotExist'

### DIFF
--- a/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/ServiceProvider.java
+++ b/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/ServiceProvider.java
@@ -37,11 +37,11 @@ public class ServiceProvider {
         return identifyHandler.handle();
     }
 
-    public Iterator<MetadataFormat> listMetadataFormats () {
+    public Iterator<MetadataFormat> listMetadataFormats () throws IdDoesNotExistException {
         return listMetadataFormatsHandler.handle(ListMetadataParameters.request()).iterator();
     }
 
-    public Iterator<MetadataFormat> listMetadataFormats (ListMetadataParameters parameters) {
+    public Iterator<MetadataFormat> listMetadataFormats (ListMetadataParameters parameters) throws IdDoesNotExistException {
         return listMetadataFormatsHandler.handle(parameters).iterator();
     }
 

--- a/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/handler/ListMetadataFormatsHandler.java
+++ b/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/handler/ListMetadataFormatsHandler.java
@@ -11,6 +11,7 @@ package org.dspace.xoai.serviceprovider.handler;
 import com.lyncode.xml.exceptions.XmlReaderException;
 import org.dspace.xoai.model.oaipmh.MetadataFormat;
 import org.dspace.xoai.serviceprovider.client.OAIClient;
+import org.dspace.xoai.serviceprovider.exceptions.IdDoesNotExistException;
 import org.dspace.xoai.serviceprovider.exceptions.InvalidOAIResponse;
 import org.dspace.xoai.serviceprovider.exceptions.OAIRequestException;
 import org.dspace.xoai.serviceprovider.model.Context;
@@ -31,7 +32,7 @@ public class ListMetadataFormatsHandler {
     }
 
 
-    public List<MetadataFormat> handle(ListMetadataParameters parameters) {
+    public List<MetadataFormat> handle(ListMetadataParameters parameters) throws IdDoesNotExistException {
         List<MetadataFormat> result = new ArrayList<MetadataFormat>();
         try {
             MetadataFormatParser parser = new MetadataFormatParser(client.execute(parameters()

--- a/xoai-service-provider/src/test/java/org/dspace/xoai/serviceprovider/ServiceProviderTest.java
+++ b/xoai-service-provider/src/test/java/org/dspace/xoai/serviceprovider/ServiceProviderTest.java
@@ -19,6 +19,7 @@ import org.dspace.xoai.serviceprovider.exceptions.IdDoesNotExistException;
 import org.dspace.xoai.serviceprovider.exceptions.NoSetHierarchyException;
 import org.dspace.xoai.serviceprovider.parameters.GetRecordParameters;
 import org.dspace.xoai.serviceprovider.parameters.ListIdentifiersParameters;
+import org.dspace.xoai.serviceprovider.parameters.ListMetadataParameters;
 import org.dspace.xoai.serviceprovider.parameters.ListRecordsParameters;
 import org.junit.Test;
 
@@ -51,6 +52,11 @@ public class ServiceProviderTest extends AbstractServiceProviderTest {
         assertThat(metadataFormatIterator.hasNext(), is(true));
         MetadataFormat metadataFormat = metadataFormatIterator.next();
         assertThat(metadataFormat.getMetadataPrefix(), equalTo(FORMAT));
+    }
+
+    @Test(expected = IdDoesNotExistException.class)
+    public void recordNotFoundForListMetadataFormats () throws Exception {
+        underTest.listMetadataFormats(ListMetadataParameters.request().withIdentifier("asd"));
     }
 
     @Test(expected = IdDoesNotExistException.class)


### PR DESCRIPTION
The service provider should support `idDoesNotExist` (as returned by the data provider) when an unknown id is used in a `ListMetadataFormats` request.
