### PR TITLE
Close stream in ListSetsHandler

### DIFF
--- a/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/client/HttpOAIClient.java
+++ b/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/client/HttpOAIClient.java
@@ -78,6 +78,7 @@ public class HttpOAIClient implements OAIClient {
 		initHttpClient();
 	}
 
+	@Override
 	public InputStream execute(Parameters parameters) throws HttpException {
 		try {
 			HttpResponse response = httpclient

--- a/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/handler/ListSetsHandler.java
+++ b/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/handler/ListSetsHandler.java
@@ -71,21 +71,17 @@ public class ListSetsHandler implements Source<Set> {
                         resumptionToken = text;
                 } else ended = true;
             } else ended = true;
+            stream.close();
             return sets;
         } catch (XmlReaderException e) {
             throw new InvalidOAIResponse(e);
         } catch (OAIRequestException e) {
             throw new InvalidOAIResponse(e);
+        } catch (IOException e){
+            throw new InvalidOAIResponse(e);
         }
         finally {
-            if(stream != null){
-                try {
-                    stream.close();
-                }
-                catch (IOException e){
-                    throw new InvalidOAIResponse(e);
-                }
-            }
+            IOUtils.closeQuietly(stream);
         }
     }
 

--- a/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/handler/ListSetsHandler.java
+++ b/xoai-service-provider/src/main/java/org/dspace/xoai/serviceprovider/handler/ListSetsHandler.java
@@ -10,6 +10,7 @@ package org.dspace.xoai.serviceprovider.handler;
 
 import com.lyncode.xml.XmlReader;
 import com.lyncode.xml.exceptions.XmlReaderException;
+import org.apache.commons.io.IOUtils;
 import org.dspace.xoai.model.oaipmh.Set;
 import org.dspace.xoai.serviceprovider.client.OAIClient;
 import org.dspace.xoai.serviceprovider.exceptions.InvalidOAIResponse;
@@ -20,6 +21,7 @@ import org.dspace.xoai.serviceprovider.parsers.ListSetsParser;
 import org.hamcrest.Matcher;
 
 import javax.xml.stream.events.XMLEvent;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,8 +47,8 @@ public class ListSetsHandler implements Source<Set> {
     @Override
     public List<Set> nextIteration() {
         List<Set> sets = new ArrayList<Set>();
+        InputStream stream = null;
         try {
-            InputStream stream = null;
             if (resumptionToken == null) { // First call
                 stream = client.execute(parameters()
                         .withVerb(ListSets));
@@ -74,6 +76,16 @@ public class ListSetsHandler implements Source<Set> {
             throw new InvalidOAIResponse(e);
         } catch (OAIRequestException e) {
             throw new InvalidOAIResponse(e);
+        }
+        finally {
+            if(stream != null){
+                try {
+                    stream.close();
+                }
+                catch (IOException e){
+                    throw new InvalidOAIResponse(e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
ListSetsHandler should close his stream otherwise it will result in a `java.lang.IllegalStateException: Invalid use of BasicClientConnManager: connection still allocated.` when used with the `HttpOAIClient` and the sets are returned over more than 1 page.
