### PR TITLE
Handle cases when unknown metadataPrefix is received

### DIFF
--- a/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListIdentifiersHandler.java
+++ b/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListIdentifiersHandler.java
@@ -41,6 +41,11 @@ public class ListIdentifiersHandler extends VerbHandler<ListIdentifiers> {
         if (parameters.hasSet() && !getRepository().getSetRepository().supportSets())
             throw new DoesNotSupportSetsException();
 
+        MetadataFormat format = getContext().formatForPrefix(parameters.getMetadataPrefix());
+        if (format == null) {
+            throw new CannotDisseminateFormatException("Format "+parameters.getMetadataPrefix()+" unknown");
+        }
+
         int length = getRepository().getConfiguration().getMaxListIdentifiers();
         int offset = getOffset(parameters);
         ListItemIdentifiersResult listItemIdentifiersResult;

--- a/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListIdentifiersHandler.java
+++ b/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListIdentifiersHandler.java
@@ -10,6 +10,7 @@ package org.dspace.xoai.dataprovider.handlers;
 
 import org.dspace.xoai.dataprovider.exceptions.*;
 import org.dspace.xoai.dataprovider.handlers.helpers.ItemRepositoryHelper;
+import org.dspace.xoai.dataprovider.handlers.helpers.PreconditionHelper;
 import org.dspace.xoai.dataprovider.handlers.helpers.ResumptionTokenHelper;
 import org.dspace.xoai.dataprovider.handlers.results.ListItemIdentifiersResult;
 import org.dspace.xoai.dataprovider.model.Context;
@@ -41,10 +42,7 @@ public class ListIdentifiersHandler extends VerbHandler<ListIdentifiers> {
         if (parameters.hasSet() && !getRepository().getSetRepository().supportSets())
             throw new DoesNotSupportSetsException();
 
-        MetadataFormat format = getContext().formatForPrefix(parameters.getMetadataPrefix());
-        if (format == null) {
-            throw new CannotDisseminateFormatException("Format "+parameters.getMetadataPrefix()+" unknown");
-        }
+        PreconditionHelper.checkMetadataFormat(getContext(), parameters.getMetadataPrefix());
 
         int length = getRepository().getConfiguration().getMaxListIdentifiers();
         int offset = getOffset(parameters);

--- a/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListRecordsHandler.java
+++ b/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListRecordsHandler.java
@@ -52,6 +52,11 @@ public class ListRecordsHandler extends VerbHandler<ListRecords> {
         if (parameters.hasSet() && !getRepository().getSetRepository().supportSets())
             throw new DoesNotSupportSetsException();
 
+        MetadataFormat format = getContext().formatForPrefix(parameters.getMetadataPrefix());
+        if (format == null) {
+            throw new CannotDisseminateFormatException("Format "+parameters.getMetadataPrefix()+" unknown");
+        }
+
         log.debug("Getting items from data source");
         int offset = getOffset(parameters);
         ListItemsResults result;

--- a/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListRecordsHandler.java
+++ b/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/ListRecordsHandler.java
@@ -13,6 +13,7 @@ import org.apache.log4j.Logger;
 import org.dspace.xoai.dataprovider.exceptions.*;
 import org.dspace.xoai.dataprovider.handlers.helpers.ItemHelper;
 import org.dspace.xoai.dataprovider.handlers.helpers.ItemRepositoryHelper;
+import org.dspace.xoai.dataprovider.handlers.helpers.PreconditionHelper;
 import org.dspace.xoai.dataprovider.handlers.helpers.ResumptionTokenHelper;
 import org.dspace.xoai.dataprovider.handlers.helpers.SetRepositoryHelper;
 import org.dspace.xoai.dataprovider.handlers.results.ListItemsResults;
@@ -46,16 +47,14 @@ public class ListRecordsHandler extends VerbHandler<ListRecords> {
     }
 
     @Override
-    public ListRecords handle(OAICompiledRequest parameters) throws OAIException, HandlerException {ListRecords res = new ListRecords();
+    public ListRecords handle(OAICompiledRequest parameters) throws OAIException, HandlerException {
+        ListRecords res = new ListRecords();
         int length = getRepository().getConfiguration().getMaxListRecords();
 
         if (parameters.hasSet() && !getRepository().getSetRepository().supportSets())
             throw new DoesNotSupportSetsException();
 
-        MetadataFormat format = getContext().formatForPrefix(parameters.getMetadataPrefix());
-        if (format == null) {
-            throw new CannotDisseminateFormatException("Format "+parameters.getMetadataPrefix()+" unknown");
-        }
+        PreconditionHelper.checkMetadataFormat(getContext(), parameters.getMetadataPrefix());
 
         log.debug("Getting items from data source");
         int offset = getOffset(parameters);

--- a/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/helpers/PreconditionHelper.java
+++ b/xoai-data-provider/src/main/java/org/dspace/xoai/dataprovider/handlers/helpers/PreconditionHelper.java
@@ -1,0 +1,25 @@
+package org.dspace.xoai.dataprovider.handlers.helpers;
+
+import org.dspace.xoai.dataprovider.exceptions.CannotDisseminateFormatException;
+import org.dspace.xoai.dataprovider.model.Context;
+import org.dspace.xoai.dataprovider.model.MetadataFormat;
+
+/**
+ * Helper class used to centralize preconditions for the different handlers.
+ */
+public class PreconditionHelper {
+
+  /**
+   * Checks that the provided metadataPrefix can be retrieved from the given {@link Context}.
+   * @param context expected to be not null
+   * @param metadataPrefix
+   * @throws CannotDisseminateFormatException
+   */
+  public static void checkMetadataFormat(Context context, String metadataPrefix)
+          throws CannotDisseminateFormatException {
+    MetadataFormat format = context.formatForPrefix(metadataPrefix);
+    if (format == null) {
+        throw new CannotDisseminateFormatException("Format " + metadataPrefix + " unknown");
+    }
+  }
+}

--- a/xoai-data-provider/src/test/java/org/dspace/xoai/dataprovider/handlers/ListIdentifiersHandlerTest.java
+++ b/xoai-data-provider/src/test/java/org/dspace/xoai/dataprovider/handlers/ListIdentifiersHandlerTest.java
@@ -9,11 +9,15 @@
 package org.dspace.xoai.dataprovider.handlers;
 
 import org.dspace.xoai.dataprovider.exceptions.BadArgumentException;
+import org.dspace.xoai.dataprovider.exceptions.CannotDisseminateFormatException;
 import org.dspace.xoai.dataprovider.exceptions.DoesNotSupportSetsException;
 import org.dspace.xoai.dataprovider.exceptions.NoMatchesException;
 import org.junit.Test;
 
 import static com.lyncode.test.matchers.xml.XPathMatchers.xPath;
+import static org.dspace.xoai.dataprovider.model.InMemoryItem.item;
+import static org.dspace.xoai.dataprovider.model.MetadataFormat.identity;
+import static org.dspace.xoai.model.oaipmh.Verb.Type.GetRecord;
 import static org.dspace.xoai.model.oaipmh.Verb.Type.ListIdentifiers;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,6 +29,14 @@ public class ListIdentifiersHandlerTest extends AbstractHandlerTest {
     public void metadataPrefixIsMandatory () throws Exception {
         underTest.handle(a(request()
                 .withVerb(ListIdentifiers)));
+    }
+
+    @Test(expected = CannotDisseminateFormatException.class)
+    public void cannotDisseminateFormat() throws Exception {
+        theItemRepository().withItem(item().withDefaults().withIdentifier("1"));
+        aContext().withMetadataFormat(EXISTING_METADATA_FORMAT, identity());
+        underTest.handle(a(request().withVerb(ListIdentifiers)
+              .withMetadataPrefix("abcd")));
     }
 
     @Test(expected = DoesNotSupportSetsException.class)

--- a/xoai-data-provider/src/test/java/org/dspace/xoai/dataprovider/handlers/ListRecordsHandlerTest.java
+++ b/xoai-data-provider/src/test/java/org/dspace/xoai/dataprovider/handlers/ListRecordsHandlerTest.java
@@ -9,11 +9,15 @@
 package org.dspace.xoai.dataprovider.handlers;
 
 import org.dspace.xoai.dataprovider.exceptions.BadArgumentException;
+import org.dspace.xoai.dataprovider.exceptions.CannotDisseminateFormatException;
 import org.dspace.xoai.dataprovider.exceptions.DoesNotSupportSetsException;
 import org.dspace.xoai.dataprovider.exceptions.NoMatchesException;
 import org.junit.Test;
 
 import static com.lyncode.test.matchers.xml.XPathMatchers.xPath;
+import static org.dspace.xoai.dataprovider.model.InMemoryItem.item;
+import static org.dspace.xoai.dataprovider.model.MetadataFormat.identity;
+import static org.dspace.xoai.model.oaipmh.Verb.Type.GetRecord;
 import static org.dspace.xoai.model.oaipmh.Verb.Type.ListRecords;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,6 +29,15 @@ public class ListRecordsHandlerTest extends AbstractHandlerTest {
     public void missingMetadataFormat() throws Exception {
         underTest.handle(request()
                 .withVerb(ListRecords));
+    }
+
+    @Test(expected = CannotDisseminateFormatException.class)
+    public void cannotDisseminateFormat() throws Exception {
+        theItemRepository().withItem(item().withDefaults().withIdentifier("1"));
+        aContext().withMetadataFormat(EXISTING_METADATA_FORMAT, identity());
+
+        underTest.handle(a(request().withVerb(ListRecords)
+                .withMetadataPrefix("abcd")));
     }
 
     @Test(expected = NoMatchesException.class)


### PR DESCRIPTION
Handling of cases when ListIdentifiers or ListRecords request includes an unknown metadata prefix.
