### PR TITLE
Replace Xalan with Saxon-HE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
             <version>1.3</version>
         </dependency>
         <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>2.7.0</version>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>9.8.0-14</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
We encountered a bug where Xalan can't handle special characters in attribute values (OAI-PMH API produces 500 error), the bug is documented here [XALANJ-2419](https://issues.apache.org/jira/browse/XALANJ-2419). It also seems that Xalan is no longer actively maintained and the 2.7.0 version is over 10 years old.

Should be easy to port to master branch also.