### PR TITLE
DS-4130 - Fix xoai Travis CI builds by updating jdk to oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - openjdk6
+  - oraclejdk8


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4130

Travis CI builds for xoai have been broken for a while, due to openjdk6 not being available in that package name any longer. As JDK6 is EOL and DSpace Travis builds all use oraclejdk8, I think the most appropriate fix is to match the JDK used for xoai.

I've tested a local build and it builds fine using JDK 8. If Travis CI passes this PR, then we'll see if it fixes the issue mentioned in DS-4130