### PR TITLE
DS-4130 Backport to 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - openjdk6
+  - oraclejdk8


### PR DESCRIPTION
This is an exact port (cherry-picked) of PR #69 , to fix travis CI builds and force xoai to match the same JDK used in DSpace core