### PR TITLE
JDK11 compatibility for 3.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
             <version>1.3</version>
         </dependency>
         <dependency>
-            <groupId>woodstox</groupId>
+            <groupId>org.codehaus.woodstox</groupId>
             <artifactId>wstx-asl</artifactId>
             <version>3.2.0</version>
         </dependency>
@@ -227,9 +227,14 @@
             <version>9.8.0-14</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.2.5</version>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -243,13 +248,15 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -265,11 +272,18 @@
             <groupId>com.lyncode</groupId>
             <artifactId>test-support</artifactId>
             <version>1.0.3</version>
+            <exclusions>
+                <!-- Newer version of dom4j is specified below -->
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>dom4j</groupId>
+            <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>jaxen</groupId>


### PR DESCRIPTION
This small PR updates the dependencies of the 3.x branch of XOAI to be compatible with JDK11.

Currently there are several XOAI dependencies that throw this WARNING when compiled in JDK11 (this may also occur as early as JDK9): 
`WARNING: An illegal reflective access operation has occurred`

This PR simply updates the dependencies to later versions which no longer throw this warning.

Loosely related to DSpace's upgrade to JDK11 (but also applicable for other projects) https://github.com/DSpace/DSpace/pull/2654