### PR TITLE
Fix: MaxListIdentifiersSize cannot be configured. 

### DIFF
--- a/src/main/java/com/lyncode/xoai/dataprovider/core/XOAIManager.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/core/XOAIManager.java
@@ -50,7 +50,7 @@ public class XOAIManager {
         format = new MetadataFormatManager(resolver, config.getFormats(), filter);
         set = new StaticSetManager(config.getSets(), filter);
         listSetsSize = config.getMaxListSetsSize();
-        listIdentifiersSize = config.getMaxListRecordsSize();
+        listIdentifiersSize = config.getMaxListIdentifiersSize();
         listRecordsSize = config.getMaxListRecordsSize();
         identation = config.getIndented();
         styleSheet = config.getStylesheet();


### PR DESCRIPTION
Fix the configuration for listIdentifiersSize. There are different getter for listIdentifiersSize  and listRecordsSize.