### PR TITLE
clear saxons internal document pool - the transformer is cached in dspace

### DIFF
--- a/src/main/java/com/lyncode/xoai/util/XSLPipeline.java
+++ b/src/main/java/com/lyncode/xoai/util/XSLPipeline.java
@@ -5,6 +5,9 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+
+import net.sf.saxon.jaxp.TransformerImpl;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -24,6 +27,13 @@ public class XSLPipeline {
         xslTransformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, (omitXMLDeclaration) ? "yes" : "no");
         xslTransformer.transform(new StreamSource(inputStream), new StreamResult(outputStream));
         inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+        
+        // see https://github.com/DSpace/DSpace/issues/8846
+        // (High memory usage on OAI-PMH interface during and after harvesting)        
+        if (xslTransformer instanceof TransformerImpl) {
+			((TransformerImpl) xslTransformer).getUnderlyingController().clearDocumentPool();
+		}
+        
         return this;
     }
 


### PR DESCRIPTION
see  https://github.com/DSpace/DSpace/issues/8846