### PR TITLE
Switch CI from Travis to GitHub.  Add Code Scanning.

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,52 @@
+# XOAI Continuous Integration/Build via GitHub Actions
+# Concepts borrowed from
+# https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-java-with-maven
+name: Build
+
+# Run this Build for all pushes / PRs to current branch
+on: [push, pull_request]
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      # Give Maven 1GB of memory to work with
+      MAVEN_OPTS: "-Xmx1024M"
+    name: Run Tests
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      # https://github.com/actions/setup-java
+      - name: Install JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      # https://github.com/actions/cache
+      - name: Cache Maven dependencies
+        uses: actions/cache@v3
+        with:
+          # Cache entire ~/.m2/repository
+          path: ~/.m2/repository
+          # Cache key is hash of all pom.xml files. Therefore any changes to POMs will invalidate cache
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      # Run parallel Maven builds based on the above 'strategy.matrix'
+      - name: Run Maven Tests
+        run: mvn --no-transfer-progress -V test
+
+      # If previous step failed, save results of tests to downloadable artifact for this job
+      # (This artifact is downloadable at the bottom of any job's summary page)
+      - name: Upload Results of Test to Artifact
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test results
+          path: "**/target/surefire-reports/**"

--- a/.github/codescan.yml
+++ b/.github/codescan.yml
@@ -1,0 +1,62 @@
+# XOAI CodeQL code scanning configuration for GitHub
+# https://docs.github.com/en/code-security/code-scanning
+#
+# NOTE: Code scanning must be run separate from our default build.yml
+# because CodeQL requires a fresh build with all tests *disabled*.
+name: "Code Scanning"
+
+# Run this code scan for all pushes / PRs to main or maintenance branches. Also run once a week.
+on:
+  push:
+    branches:
+      - main
+      - '3.x'
+  pull_request:
+    branches:
+      - main
+      - '3.x'
+    # Don't run if PR is only updating static documentation
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+  schedule:
+    - cron: "37 0 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze Code
+    runs-on: ubuntu-latest
+    # Limit permissions of this GitHub action. Can only write to security-events
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # https://github.com/actions/setup-java
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      # Initializes the CodeQL tools for scanning.
+      # https://github.com/github/codeql-action
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: java
+
+      # Autobuild attempts to build any compiled languages
+      # NOTE: Based on testing, this autobuild process works well for DSpace. A custom
+      # DSpace build w/caching (like in build.yml) was about the same speed as autobuild.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # Perform GitHub Code Scanning.
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-sudo: false
-dist: trusty
-
-jdk:
-  - oraclejdk8


### PR DESCRIPTION
Small PR to enable GitHub build & testing along with Code Scanning.  No changes to the actual Java code.  This just removes old Travis settings in favor of GitHub Actions.