### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
@@ -234,7 +235,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.3</version>
+            <version>1.16.0</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>
@@ -249,34 +250,34 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.1</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.lyncode</groupId>
@@ -287,6 +288,7 @@
             <groupId>com.lyncode</groupId>
             <artifactId>test-support</artifactId>
             <version>1.0.3</version>
+            <scope>test</scope>
             <exclusions>
                 <!-- Newer version of dom4j is specified below -->
                 <exclusion>
@@ -298,7 +300,8 @@
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.4</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jaxen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -223,14 +223,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>wstx-asl</artifactId>
-            <version>3.2.0</version>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.2.4</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/src/main/java/com/lyncode/xoai/dataprovider/OAIDataProvider.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/OAIDataProvider.java
@@ -34,8 +34,8 @@ import com.lyncode.xoai.dataprovider.xml.oaipmh.OAIPMH;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.OAIPMHtype;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.RequestType;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.VerbType;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.OutputStream;

--- a/src/main/java/com/lyncode/xoai/dataprovider/OAIRequestParameters.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/OAIRequestParameters.java
@@ -18,8 +18,8 @@ package com.lyncode.xoai.dataprovider;
 import com.lyncode.xoai.dataprovider.exceptions.DuplicateDefinitionException;
 import com.lyncode.xoai.dataprovider.exceptions.IllegalVerbException;
 import com.lyncode.xoai.dataprovider.exceptions.UnknownParameterException;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/lyncode/xoai/dataprovider/core/ItemMetadata.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/core/ItemMetadata.java
@@ -2,8 +2,8 @@ package com.lyncode.xoai.dataprovider.core;
 
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import com.lyncode.xoai.dataprovider.xml.xoai.XOAIParser;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;

--- a/src/main/java/com/lyncode/xoai/dataprovider/core/OAIParameters.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/core/OAIParameters.java
@@ -22,8 +22,8 @@ import com.lyncode.xoai.dataprovider.services.api.DateProvider;
 import com.lyncode.xoai.dataprovider.services.api.ResumptionTokenFormatter;
 import com.lyncode.xoai.dataprovider.services.impl.BaseDateProvider;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.VerbType;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.text.ParseException;
 import java.util.Calendar;

--- a/src/main/java/com/lyncode/xoai/dataprovider/core/XOAIContext.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/core/XOAIContext.java
@@ -23,8 +23,8 @@ import com.lyncode.xoai.dataprovider.data.internal.MetadataTransformer;
 import com.lyncode.xoai.dataprovider.exceptions.CannotDisseminateFormatException;
 import com.lyncode.xoai.dataprovider.filter.conditions.Condition;
 import com.lyncode.xoai.dataprovider.sets.StaticSet;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/com/lyncode/xoai/dataprovider/data/internal/SetRepositoryHelper.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/data/internal/SetRepositoryHelper.java
@@ -5,8 +5,8 @@ import com.lyncode.xoai.dataprovider.core.Set;
 import com.lyncode.xoai.dataprovider.core.XOAIContext;
 import com.lyncode.xoai.dataprovider.services.api.SetRepository;
 import com.lyncode.xoai.dataprovider.sets.StaticSet;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/lyncode/xoai/dataprovider/format/MetadataFormatManager.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/format/MetadataFormatManager.java
@@ -23,8 +23,8 @@ import com.lyncode.xoai.dataprovider.exceptions.ConfigurationException;
 import com.lyncode.xoai.dataprovider.filter.FilterManager;
 import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.FormatConfiguration;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;

--- a/src/main/java/com/lyncode/xoai/dataprovider/handlers/IdentifyHandler.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/handlers/IdentifyHandler.java
@@ -11,8 +11,8 @@ import com.lyncode.xoai.dataprovider.xml.oaipmh.DescriptionType;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.IdentifyType;
 import com.lyncode.xoai.dataprovider.xml.xoaidescription.XOAIDescription;
 import com.lyncode.xoai.util.MarshallingUtils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/lyncode/xoai/dataprovider/handlers/ListRecordsHandler.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/handlers/ListRecordsHandler.java
@@ -12,8 +12,8 @@ import com.lyncode.xoai.dataprovider.services.api.DateProvider;
 import com.lyncode.xoai.dataprovider.services.api.RepositoryConfiguration;
 import com.lyncode.xoai.dataprovider.services.api.ResumptionTokenFormatter;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.*;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.TransformerException;

--- a/src/main/java/com/lyncode/xoai/dataprovider/handlers/ListSetsHandler.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/handlers/ListSetsHandler.java
@@ -13,8 +13,8 @@ import com.lyncode.xoai.dataprovider.xml.oaipmh.ListSetsType;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.ResumptionTokenType;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.SetType;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.List;
 

--- a/src/main/java/com/lyncode/xoai/dataprovider/services/impl/DefaultResumptionTokenFormatter.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/services/impl/DefaultResumptionTokenFormatter.java
@@ -4,8 +4,8 @@ import com.lyncode.xoai.dataprovider.core.ResumptionToken;
 import com.lyncode.xoai.dataprovider.exceptions.BadResumptionToken;
 import com.lyncode.xoai.dataprovider.services.api.ResumptionTokenFormatter;
 import com.lyncode.xoai.util.Base64Utils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/src/main/java/com/lyncode/xoai/serviceprovider/OAIServiceConfiguration.java
+++ b/src/main/java/com/lyncode/xoai/serviceprovider/OAIServiceConfiguration.java
@@ -5,11 +5,12 @@ import com.lyncode.xoai.serviceprovider.parser.AboutItemParser;
 import com.lyncode.xoai.serviceprovider.parser.AboutSetParser;
 import com.lyncode.xoai.serviceprovider.parser.DescriptionParser;
 import com.lyncode.xoai.serviceprovider.parser.MetadataParser;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 
 public abstract class OAIServiceConfiguration<M extends MetadataParser, A extends AboutItemParser, D extends DescriptionParser, S extends AboutSetParser> {
-    private static Logger log = Logger.getLogger(OAIServiceConfiguration.class);
+    private static Logger log = LogManager.getLogger(OAIServiceConfiguration.class);
     private static final int INTERVAL = 1000;
 
     private DateProvider formatter;

--- a/src/main/java/com/lyncode/xoai/util/MarshallingUtils.java
+++ b/src/main/java/com/lyncode/xoai/util/MarshallingUtils.java
@@ -5,8 +5,8 @@ import com.lyncode.xoai.dataprovider.xml.PrefixMapper;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import com.lyncode.xoai.dataprovider.xml.xoaidescription.XOAIDescription;
 import com.lyncode.xoai.dataprovider.exceptions.MetadataBindException;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;


### PR DESCRIPTION
Update dependencies in POM to later versions & cleanup test dependencies in POM. Many have not been updated in some time.

Includes updating to log4j2 and latest Woodstox.  