### PR TITLE
Remove unmaintained Lyncode dependencies and copy their exact code into codebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,13 +229,18 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
+            <artifactId>log4j-core</artifactId>
             <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.16.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>
@@ -280,22 +285,9 @@
             <version>2.13.0</version>
         </dependency>
         <dependency>
-            <groupId>com.lyncode</groupId>
-            <artifactId>builder-commons</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.lyncode</groupId>
-            <artifactId>test-support</artifactId>
-            <version>1.0.3</version>
-            <scope>test</scope>
-            <exclusions>
-                <!-- Newer version of dom4j is specified below -->
-                <exclusion>
-                    <groupId>dom4j</groupId>
-                    <artifactId>dom4j</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.0.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>

--- a/src/main/java/com/lyncode/xoai/builders/Builder.java
+++ b/src/main/java/com/lyncode/xoai/builders/Builder.java
@@ -1,0 +1,5 @@
+package com.lyncode.builder;
+
+public interface Builder<T> {
+    T build();
+}

--- a/src/main/java/com/lyncode/xoai/builders/DateBuilder.java
+++ b/src/main/java/com/lyncode/xoai/builders/DateBuilder.java
@@ -1,0 +1,46 @@
+package com.lyncode.builder;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public class DateBuilder implements Builder<Date> {
+    public static final int MIN_MILLISECONDS = 0;
+    public static final int MAX_MILLISECONDS = 999;
+    private Calendar calendar = Calendar.getInstance();
+
+    public DateBuilder() {
+    }
+
+    public DateBuilder(Date time) {
+        calendar.setTime(time);
+    }
+
+    public DateBuilder addDays(int days) {
+        calendar.add(Calendar.DAY_OF_YEAR, days);
+        return this;
+    }
+
+    public DateBuilder subtractDays(int days) {
+        calendar.add(Calendar.DAY_OF_YEAR, days * -1);
+        return this;
+    }
+
+    public DateBuilder setMilliseconds(int milliseconds) {
+        calendar.set(Calendar.MILLISECOND, milliseconds);
+        return this;
+    }
+
+    public DateBuilder setMinMilliseconds() {
+        calendar.set(Calendar.MILLISECOND, MIN_MILLISECONDS);
+        return this;
+    }
+
+    public DateBuilder setMaxMilliseconds() {
+        calendar.set(Calendar.MILLISECOND, MAX_MILLISECONDS);
+        return this;
+    }
+
+    public Date build() {
+        return calendar.getTime();
+    }
+}

--- a/src/main/java/com/lyncode/xoai/builders/ListBuilder.java
+++ b/src/main/java/com/lyncode/xoai/builders/ListBuilder.java
@@ -1,0 +1,37 @@
+package com.lyncode.builder;
+
+import com.google.common.base.Function;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.collect.Collections2.transform;
+import static com.google.common.collect.Lists.newArrayList;
+
+public class ListBuilder<T> implements Builder<List<T>> {
+    private List<T> list;
+
+    public ListBuilder() {
+        list = new ArrayList<T>();
+    }
+
+    public ListBuilder<T> add(Collection<T> list) {
+        this.list.addAll(list);
+        return this;
+    }
+
+    public ListBuilder<T> add(T... list) {
+        for (T t : list)
+            this.list.add(t);
+        return this;
+    }
+
+    public List<T> build() {
+        return list;
+    }
+
+    public <E> List<E> build(Function<T, E> transformer) {
+        return newArrayList(transform(list, transformer));
+    }
+}

--- a/src/main/java/com/lyncode/xoai/builders/MapBuilder.java
+++ b/src/main/java/com/lyncode/xoai/builders/MapBuilder.java
@@ -1,0 +1,17 @@
+package com.lyncode.builder;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class MapBuilder<K, V> implements Builder<Map<K, V>> {
+    private Map<K, V> map = new TreeMap<K, V>();
+
+    public MapBuilder withPair(K key, V value) {
+        map.put(key, value);
+        return this;
+    }
+
+    public Map<K, V> build() {
+        return this.map;
+    }
+}

--- a/src/test/java/com/lyncode/test/matchers/string/PatternMatcher.java
+++ b/src/test/java/com/lyncode/test/matchers/string/PatternMatcher.java
@@ -1,0 +1,90 @@
+package com.lyncode.test.matchers.string;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.regex.Pattern;
+
+/**
+ * Tests if the argument is a {@link CharSequence} that matches a regular expression.
+ */
+public class PatternMatcher extends TypeSafeMatcher<CharSequence> {
+
+    /**
+     * Creates a matcher that matches if the examined {@link CharSequence} matches the specified
+     * regular expression.
+     * <p/>
+     * For example:
+     * <pre>assertThat("myStringOfNote", pattern("[0-9]+"))</pre>
+     *
+     * @param regex the regular expression that the returned matcher will use to match any examined {@link CharSequence}
+     */
+    @Factory
+    public static Matcher<CharSequence> pattern(String regex) {
+        return pattern(Pattern.compile(regex));
+    }
+
+    /**
+     * Creates a matcher that matches if the examined {@link CharSequence} matches the specified
+     * {@link java.util.regex.Pattern}.
+     * <p/>
+     * For example:
+     * <pre>assertThat("myStringOfNote", Pattern.compile("[0-9]+"))</pre>
+     *
+     * @param pattern the pattern that the returned matcher will use to match any examined {@link CharSequence}
+     */
+    @Factory
+    public static Matcher<CharSequence> pattern(Pattern pattern) {
+        return new PatternMatcher(pattern);
+    }
+
+    public static Matcher<CharSequence> pattern (final String pattern, final int group, final Matcher<? super String> matcher) {
+        return new TypeSafeMatcher<CharSequence>() {
+            @Override
+            protected boolean matchesSafely(CharSequence item) {
+                java.util.regex.Matcher match = Pattern.compile(pattern).matcher(item);
+                match.find();
+                return matcher.matches(match.group(group));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Group ")
+                           .appendValue(group)
+                           .appendText(" in pattern ")
+                           .appendValue(pattern)
+                           .appendDescriptionOf(matcher);
+            }
+
+            @Override
+            protected void describeMismatchSafely(CharSequence item, Description mismatchDescription) {
+                java.util.regex.Matcher match = Pattern.compile(pattern).matcher(item);
+                match.find();
+                mismatchDescription.appendText(match.group(group));
+            }
+        };
+    }
+
+    private final Pattern pattern;
+
+    public PatternMatcher(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public boolean matchesSafely(CharSequence item) {
+        return pattern.matcher(item).matches();
+    }
+
+    @Override
+    public void describeMismatchSafely(CharSequence item, org.hamcrest.Description mismatchDescription) {
+        mismatchDescription.appendText("was \"").appendText(String.valueOf(item)).appendText("\"");
+    }
+
+    @Override
+    public void describeTo(org.hamcrest.Description description) {
+        description.appendText("a string with pattern \"").appendText(String.valueOf(pattern)).appendText("\"");
+    }
+}

--- a/src/test/java/com/lyncode/test/matchers/xml/XPathMatchers.java
+++ b/src/test/java/com/lyncode/test/matchers/xml/XPathMatchers.java
@@ -1,0 +1,136 @@
+package com.lyncode.test.matchers.xml;
+
+import com.lyncode.builder.MapBuilder;
+import org.dom4j.*;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class XPathMatchers {
+    private static final String DEFAULT_PREFIX = "defprefix";
+
+    private static String replaceXpath(String xpath) {
+        int offset = 0;
+        String newXpath = "";
+        Pattern pattern = Pattern.compile("/[^/]+");
+        java.util.regex.Matcher matcher = pattern.matcher(xpath);
+        while (matcher.find()) {
+            if (matcher.start() > offset) newXpath += xpath.substring(offset, matcher.start());
+            if (!matcher.group().contains(":") && !matcher.group().startsWith("/@"))
+                newXpath += "/" + DEFAULT_PREFIX + ":" + matcher.group().substring(1);
+            else
+                newXpath += matcher.group();
+            offset = matcher.end() + 1;
+        }
+
+        return newXpath;
+    }
+
+    public static <T> XPathValueMatcher xPath(String expression, Matcher<T> value) {
+        return new XPathValueMatcher(expression, value);
+    }
+
+    public static <T> XPathValueMatcher xPath(String expression, Matcher<T> value, String defaultNamespace) {
+        return xPath(replaceXpath(expression), value, new MapBuilder<String, String>().withPair(DEFAULT_PREFIX, defaultNamespace));
+    }
+
+    public static <T> XPathValueMatcher xPath(String expression, Matcher<T> value, MapBuilder<String, String> namespaces) {
+        return new XPathValueMatcher(expression, value, namespaces);
+    }
+
+    public static XPathMatcher hasXPath(String expression) {
+        return new XPathMatcher(expression);
+    }
+
+    public static XPathMatcher hasXPath(String expression, String defaultNamespace) {
+        return new XPathMatcher(replaceXpath(expression), new MapBuilder<String, String>().withPair(DEFAULT_PREFIX, defaultNamespace));
+    }
+
+    public static XPathMatcher hasXPath(String expression, MapBuilder<String, String> namespaces) {
+        return new XPathMatcher(expression, namespaces);
+    }
+
+    private static class XPathMatcher extends BaseMatcher<String> {
+        private String expression;
+        private MapBuilder<String, String> contexts;
+
+        public XPathMatcher(String expression) {
+            this.expression = expression;
+        }
+
+        public XPathMatcher(String expression, MapBuilder<String, String> namespaces) {
+            this.expression = expression;
+            this.contexts = namespaces;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            if (o instanceof String) {
+                String input = (String) o;
+                try {
+                    Document document = DocumentHelper.parseText(input);
+                    XPath xPath = document.createXPath(this.expression);
+                    if (this.contexts != null) {
+                        xPath.setNamespaceURIs(this.contexts.build());
+                    }
+                    List<Node> list = xPath.selectNodes(document);
+                    boolean contains = !list.isEmpty();
+                    return contains;
+                } catch (Exception e) {
+                    throw new RuntimeException(e.getMessage(), e);
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("XML with XPath ").appendValue(this.expression);
+        }
+    }
+
+    private static class XPathValueMatcher<T> extends BaseMatcher<String> {
+        private MapBuilder<String, String> namespaces;
+        private Matcher<T> value;
+        private String expression;
+
+        public XPathValueMatcher(String expression, Matcher<T> value) {
+            this.value = value;
+            this.expression = expression;
+        }
+
+        public XPathValueMatcher(String expression, Matcher<T> value, MapBuilder<String, String> namespaces) {
+            this.value = value;
+            this.expression = expression;
+            this.namespaces = namespaces;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            if (o instanceof String) {
+                String input = (String) o;
+                try {
+                    Document document = DocumentHelper.parseText(input);
+                    XPath xPath = document.createXPath(this.expression);
+                    if (this.namespaces != null)
+                        xPath.setNamespaceURIs(this.namespaces.build());
+                    String evaluatedValue = xPath.valueOf(document);
+                    return !xPath.selectNodes(document).isEmpty() && value.matches(evaluatedValue);
+                } catch (DocumentException e) {
+                    throw new RuntimeException(e.getMessage(), e);
+                }
+            }
+            System.err.println("Incorrect input");
+            return false;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("XPath ").appendValue(this.expression).appendText(" must resolve to ");
+            value.describeTo(description);
+        }
+    }
+}


### PR DESCRIPTION
For long term maintenance, replaced these dependencies with their source code:
* `builder-commons` from `com.lyncode` replaced with the 4 classes from https://github.com/lyncode/builder-commons
* `test-support` from `com.lyncode` replaced with the two classes we use. Found in its source JAR in Maven: https://repo1.maven.org/maven2/com/lyncode/test-support/1.1.0/