### PR TITLE
Update JAXB dependencies to be compile-only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,15 +247,19 @@
             <artifactId>Saxon-HE</artifactId>
             <version>9.8.0-14</version>
         </dependency>
+        <!-- JAXB is no longer bundled with Java.
+             compile only scope as this will be brought in through dspace-api -->
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.8</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This is a small PR to update the JAXB dependencies of XOAI v3 to be "compile" scope only.  That way they don't get pulled into DSpace or other projects, and this provides compatibility with both Java 11 and 17 (which moves to Jakarta)