### PR TITLE
Potential fix for code scanning alert no. 1: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/lyncode/xoai/serviceprovider/oaipmh/OAIPMHParser.java
+++ b/src/main/java/com/lyncode/xoai/serviceprovider/oaipmh/OAIPMHParser.java
@@ -21,6 +21,10 @@ public class OAIPMHParser extends ElementParser<OAIPMHtype> {
     private static final String NAME = "OAI-PMH";
     private static final String RESPONSE_DATE = "responseDate";
     private static XMLInputFactory factory = XMLInputFactory2.newInstance();
+    static {
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false); // Disable DTD processing
+        factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false); // Disable external entities
+    }
 
     private static void untilFirstStartElement(XMLEventReader reader) throws XMLStreamException {
         while (reader.peek() != null && !reader.peek().isStartElement() && !reader.peek().isEndDocument())


### PR DESCRIPTION
Potential fix for [https://github.com/DSpace/xoai/security/code-scanning/1](https://github.com/DSpace/xoai/security/code-scanning/1)

To fix the issue, we need to configure the `XMLInputFactory` instance to disable external entity resolution and DTD processing. This can be achieved by setting the following features:
1. `XMLInputFactory.SUPPORT_DTD` to `false` to disable DTD processing.
2. `"javax.xml.stream.isSupportingExternalEntities"` to `false` to prevent external entity resolution.

These changes should be applied to the `factory` instance in `OAIPMHParser`. This ensures that all XML parsing operations using this factory are secure against XXE attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
