### PR TITLE
Update dependabot rules to re-sync with DSpace settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,17 @@
 version: 2
 updates:
   ###############
-  ## Main branch
+  ## Primary (3.x) branch
   ###############
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"
       time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
     # Group together some upgrades in a single PR
@@ -53,3 +57,28 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  # Also automatically update all our GitHub actions on the primary branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "actions/*"
+          - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]


### PR DESCRIPTION
Update dependabot rules to include upgrades to GitHub actions and cooldown period.  This re-syncs us with DSpace settings, see https://github.com/DSpace/DSpace/blob/main/.github/dependabot.yml