### PR TITLE
Secure all usages of `TransformerFactory` & update to Saxon 12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
                                         <version>${java.version}</version>
                                     </requireJavaVersion>
                                     <requireMavenVersion>
-                                        <version>[3.0.5,)</version>
+                                        <version>[3.8,)</version>
                                     </requireMavenVersion>
                                 </rules>
                             </configuration>
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.9.1-8</version>
+            <version>12.9</version>
         </dependency>
         <!-- JAXB is no longer bundled with Java.
              compile only scope as this will be brought in through dspace-api -->

--- a/src/main/java/com/lyncode/xoai/dataprovider/services/impl/FileResourceResolver.java
+++ b/src/main/java/com/lyncode/xoai/dataprovider/services/impl/FileResourceResolver.java
@@ -2,6 +2,7 @@ package com.lyncode.xoai.dataprovider.services.impl;
 
 import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
 
+import com.lyncode.xoai.util.XMLUtils;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
@@ -12,7 +13,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class FileResourceResolver implements ResourceResolver {
-    private static TransformerFactory tFactory = TransformerFactory.newInstance();
     private String basePath;
 
     public FileResourceResolver(String basePath) {
@@ -27,6 +27,7 @@ public class FileResourceResolver implements ResourceResolver {
 
     @Override
     public Templates getTemplates(String path) throws IOException, TransformerConfigurationException {
+        TransformerFactory tFactory = XMLUtils.getTransformerFactory();
         return tFactory.newTemplates(new StreamSource(getResource(path)));
     }
 }

--- a/src/main/java/com/lyncode/xoai/util/XMLUtils.java
+++ b/src/main/java/com/lyncode/xoai/util/XMLUtils.java
@@ -1,7 +1,9 @@
 package com.lyncode.xoai.util;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
@@ -10,12 +12,30 @@ import java.io.ByteArrayOutputStream;
 
 
 public class XMLUtils {
-    static final TransformerFactory factory = TransformerFactory.newInstance();
+    /**
+     * Initialize and return the javax TransformerFactory with some basic security
+     * applied to avoid XXE attacks and other unwanted content inclusion
+     * @return transformer factory to generate new transformers
+     * @throws TransformerConfigurationException
+     */
+    public static TransformerFactory getTransformerFactory() throws TransformerConfigurationException {
+        TransformerFactory factory = TransformerFactory.newInstance();
+
+        // Process XML securely
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        // No external DTDs or Stylesheets
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+
+        return factory;
+    }
 
     public static String format(String unformattedXml) {
         try {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             Transformer transformer;
+            TransformerFactory factory = getTransformerFactory();
             transformer = factory.newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             //initialize StreamResult with File object to save to file

--- a/src/test/java/com/lyncode/xoai/tests/dataprovider/acceptance/AbstractDataProviderTest.java
+++ b/src/test/java/com/lyncode/xoai/tests/dataprovider/acceptance/AbstractDataProviderTest.java
@@ -24,6 +24,7 @@ import com.lyncode.xoai.dataprovider.xml.xoaiconfig.FormatConfiguration;
 import com.lyncode.xoai.tests.helpers.AbstractIdentifyBuilder;
 import com.lyncode.xoai.tests.helpers.stubs.StubbedItemRepository;
 import com.lyncode.xoai.tests.helpers.stubs.StubbedSetRepository;
+import com.lyncode.xoai.util.XMLUtils;
 import org.codehaus.stax2.XMLOutputFactory2;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
@@ -54,9 +55,6 @@ public abstract class AbstractDataProviderTest {
     private static final String XOAI_SCHEMA_LOCATION = "schemaLocation";
     private static final String XOAI_XSLT_LOCATION = "xoai-schema-location";
 
-    private static TransformerFactory tFactory = TransformerFactory.newInstance();
-
-
     private OAIDataProvider dataProvider;
     private XOAIManager manager;
     private FilterResolver filterResolver = mock(FilterResolver.class);
@@ -71,6 +69,8 @@ public abstract class AbstractDataProviderTest {
 
     @Before
     public void setUp() throws IOException, TransformerConfigurationException, ParseException {
+        TransformerFactory tFactory = XMLUtils.getTransformerFactory();
+
         when(resourceResolver.getTemplates(XOAI_XSLT_LOCATION)).
                 thenReturn(tFactory.newTemplates(new StreamSource(
                         this.getClass().getClassLoader().getResourceAsStream("identity_transform.xsl"))));

--- a/src/test/java/com/lyncode/xoai/tests/dataprovider/unit/XmlTest.java
+++ b/src/test/java/com/lyncode/xoai/tests/dataprovider/unit/XmlTest.java
@@ -3,6 +3,7 @@ package com.lyncode.xoai.tests.dataprovider.unit;
 import com.lyncode.builder.MapBuilder;
 import com.lyncode.test.matchers.xml.XPathMatchers;
 import com.lyncode.xoai.dataprovider.xml.XmlOutputContext;
+import com.lyncode.xoai.util.XMLUtils;
 import org.hamcrest.Matcher;
 
 import javax.xml.stream.XMLStreamException;
@@ -14,8 +15,6 @@ import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayOutputStream;
 
 public abstract class XmlTest {
-    private static TransformerFactory tFactory = TransformerFactory.newInstance();
-
     private ByteArrayOutputStream output;
     private XmlOutputContext context;
 
@@ -30,6 +29,7 @@ public abstract class XmlTest {
 
     protected Templates identityTemplate() {
         try {
+            TransformerFactory tFactory = XMLUtils.getTransformerFactory();
             return tFactory.newTemplates(new StreamSource(
                     this.getClass().getClassLoader().getResourceAsStream("identity_transform.xsl")));
         } catch (TransformerConfigurationException e) {

--- a/src/test/java/com/lyncode/xoai/tests/util/XSLPipelineTest.java
+++ b/src/test/java/com/lyncode/xoai/tests/util/XSLPipelineTest.java
@@ -6,7 +6,6 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -16,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class XSLPipelineTest extends XmlTest {
-    private static final TransformerFactory tFactory = TransformerFactory.newInstance();
     private static final String TEST_XML = "<test />";
 
     private ByteArrayInputStream input = new ByteArrayInputStream(TEST_XML.getBytes());


### PR DESCRIPTION
## Description

This PR ensures that all usages of `TransformerFactory` are properly secured against possible XXE style attacks.  While these attacks are unlikely (as XML is self-generated and XSLTs are in the codebase), it provides an extra level of protection.

`TransformerFactory` is only used in a few places in XOAI:
* `FileResourceResolver` - This class is unused in XOAI and unused in DSpace.  However, I've secured it just in case some other application depends on it.
* Three testing classes: `AbstractDataProviderTest`, `XmlTest` and `XSLPipelineTest` (where it wasn't actually used).

This also **requires** upgrading Saxon (to version 12) to support disabling external DTDs and Stylesheets.  Also updated minimum required Maven version to align with DSpace 8.x-10.x.

## Instructions for Reviewers
* Review Code & verify updated tests all pass
* This cannot be tested individually as the only usage of `TransformerFactory` in XOAI is in unused code (`FileResourceResolver`).  Instead, this can only easily be tested alongside https://github.com/DSpace/DSpace/pull/12681
   * Pull down this PR's code
   * Install the updated XOAI dependency in your local Maven dependencies: `mvn clean install`
   * Then, checkout the DSpace PR https://github.com/DSpace/DSpace/pull/12681 and build/update DSpace using that PR (and this updated XOAI version)
   * I've performed these tests on my local machine and found no issues in DSpace's OAI-PMH interface with this PR in place.