### PR TITLE
Add unit tests for XSLPipeline

### DIFF
--- a/src/test/java/com/lyncode/xoai/tests/util/XSLPipelineTest.java
+++ b/src/test/java/com/lyncode/xoai/tests/util/XSLPipelineTest.java
@@ -6,7 +6,6 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -16,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class XSLPipelineTest extends XmlTest {
-    private static final TransformerFactory tFactory = TransformerFactory.newInstance();
     private static final String TEST_XML = "<test />";
 
     private ByteArrayInputStream input = new ByteArrayInputStream(TEST_XML.getBytes());
@@ -44,7 +42,7 @@ public class XSLPipelineTest extends XmlTest {
     @Test
     public void shouldSupportMethodChainingOnApply() throws TransformerException, IOException {
         String result = IOUtils.toString(
-                new XSLPipeline(new ByteArrayInputStream(TEST_XML.getBytes()), true)
+                new XSLPipeline(input, true)
                         .apply(identityTemplate())
                         .getTransformed());
         assertThat(result, not(containsString("<?xml")));

--- a/src/test/java/com/lyncode/xoai/tests/util/XSLPipelineTest.java
+++ b/src/test/java/com/lyncode/xoai/tests/util/XSLPipelineTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -15,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class XSLPipelineTest extends XmlTest {
+    private static final TransformerFactory tFactory = TransformerFactory.newInstance();
     private static final String TEST_XML = "<test />";
 
     private ByteArrayInputStream input = new ByteArrayInputStream(TEST_XML.getBytes());
@@ -37,5 +39,14 @@ public class XSLPipelineTest extends XmlTest {
         XSLPipeline underTest = new XSLPipeline(input, true);
         underTest.apply(identityTemplate());
         assertThat(IOUtils.toString(underTest.getTransformed()), not(containsString("<?xml")));
+    }
+
+    @Test
+    public void shouldSupportMethodChainingOnApply() throws TransformerException, IOException {
+        String result = IOUtils.toString(
+                new XSLPipeline(new ByteArrayInputStream(TEST_XML.getBytes()), true)
+                        .apply(identityTemplate())
+                        .getTransformed());
+        assertThat(result, not(containsString("<?xml")));
     }
 }


### PR DESCRIPTION
Additive unit tests for `XSLPipeline` — edge cases and current behavior pinned with explicit assertions. No existing test or production code changed.

Verified green under Java 11 (`mvn -pl . test -Dtest=XSLPipelineTest` → Tests run: 4, Failures: 0, Errors: 0).
